### PR TITLE
Date setter

### DIFF
--- a/app/forms.py
+++ b/app/forms.py
@@ -1,5 +1,5 @@
 from flask_wtf import FlaskForm
-from wtforms import StringField, PasswordField, BooleanField, SubmitField, TextAreaField
+from wtforms import StringField, PasswordField, BooleanField, SubmitField, TextAreaField, SelectField
 from wtforms.validators import ValidationError, DataRequired, Email, EqualTo, Length
 from app.models import User
 

--- a/app/forms.py
+++ b/app/forms.py
@@ -44,8 +44,8 @@ class EditProfileForm(FlaskForm):
 
 class EditPostForm(FlaskForm):
   body = TextAreaField('Body', validators=[DataRequired(), Length(min=1, max=420)])
-  month = SelectField('Month', choices=[(0, 'Jan'), (1, 'Feb'), (2, 'Mar'), (3, 'Apr'), (4, 'May'), (5, 'Jun'), (6, 'Jul'), (7, 'Aug'), (8, 'Sep'), (9, 'Oct'), (10, 'Nov'), (11, 'Dec')], coerce=int)
-  date = SelectField('Day', choices=[(1,1), (2,2), (3,3), (4,4), (5,5), (6,6), (7,7), (8,8), (9,9), (10,10), (11,11), (12,12)], coerce=int)
+  month = SelectField('Month', choices=[(1, 'Jan'), (2, 'Feb'), (3, 'Mar'), (4, 'Apr'), (5, 'May'), (6, 'Jun'), (7, 'Jul'), (8, 'Aug'), (9, 'Sep'), (10, 'Oct'), (11, 'Nov'), (12, 'Dec')], coerce=int)
+  date = SelectField('Day', choices=[(1,1), (2,2), (3,3), (4,4), (5,5), (6,6), (7,7), (8,8), (9,9), (10,10), (11,11), (12,12), (13,13), (14,14), (15,15), (16,16), (17,17), (18,18), (19,19), (20,20), (21,21), (22,22), (23,23), (24,24), (25,25), (26,26), (27,27), (28,28), (29,29), (30,30), (31,31)], coerce=int)
   submit = SubmitField('Submit')
 
   def __init__(self, original_body, *args, **kwargs):

--- a/app/forms.py
+++ b/app/forms.py
@@ -44,6 +44,8 @@ class EditProfileForm(FlaskForm):
 
 class EditPostForm(FlaskForm):
   body = TextAreaField('Body', validators=[DataRequired(), Length(min=1, max=420)])
+  month = SelectField('Month', choices=[(0, 'Jan'), (1, 'Feb'), (2, 'Mar'), (3, 'Apr'), (4, 'May'), (5, 'Jun'), (6, 'Jul'), (7, 'Aug'), (8, 'Sep'), (9, 'Oct'), (10, 'Nov'), (11, 'Dec')])
+  day = SelectField('Day', choices=[(1,1), (2,2), (3,3), (4,4), (5,5), (6,6), (7,7), (8,8), (9,9), (10,10), (11,11), (12,12)])
   submit = SubmitField('Submit')
 
   def __init__(self, original_body, *args, **kwargs):

--- a/app/forms.py
+++ b/app/forms.py
@@ -44,8 +44,8 @@ class EditProfileForm(FlaskForm):
 
 class EditPostForm(FlaskForm):
   body = TextAreaField('Body', validators=[DataRequired(), Length(min=1, max=420)])
-  month = SelectField('Month', choices=[(0, 'Jan'), (1, 'Feb'), (2, 'Mar'), (3, 'Apr'), (4, 'May'), (5, 'Jun'), (6, 'Jul'), (7, 'Aug'), (8, 'Sep'), (9, 'Oct'), (10, 'Nov'), (11, 'Dec')])
-  day = SelectField('Day', choices=[(1,1), (2,2), (3,3), (4,4), (5,5), (6,6), (7,7), (8,8), (9,9), (10,10), (11,11), (12,12)])
+  month = SelectField('Month', choices=[(0, 'Jan'), (1, 'Feb'), (2, 'Mar'), (3, 'Apr'), (4, 'May'), (5, 'Jun'), (6, 'Jul'), (7, 'Aug'), (8, 'Sep'), (9, 'Oct'), (10, 'Nov'), (11, 'Dec')], coerce=int)
+  date = SelectField('Day', choices=[(1,1), (2,2), (3,3), (4,4), (5,5), (6,6), (7,7), (8,8), (9,9), (10,10), (11,11), (12,12)], coerce=int)
   submit = SubmitField('Submit')
 
   def __init__(self, original_body, *args, **kwargs):

--- a/app/routes.py
+++ b/app/routes.py
@@ -135,7 +135,7 @@ def edit_post():
       flash('Your changes have been saved.')
   elif request.method == 'GET':
     form.body.data = postBody
-    form.date.data = oldDate.date
+    form.date.data = oldDate.day
     form.month.data = oldDate.month
   return render_template('edit_post.html', title='Edit Post', form=form)
 

--- a/app/routes.py
+++ b/app/routes.py
@@ -122,15 +122,21 @@ def edit_profile():
 def edit_post():
   postBody = request.args.get('post')
   postId = request.args.get('postId')
+  month = request.args.get('month')
+  date = request.args.get('date')
   givenPost = Post.query.filter_by(id=postId).first()
   form = EditPostForm(postBody)
   if form.validate_on_submit():
     if givenPost:
+      newDate = givenPost.timestamp.replace(day=form.timestamp.date, month=form.timestamp.month)
       givenPost.body = form.body.data
+      givenPost.timestamp = newDate
       db.session.commit()
       flash('Your changes have been saved.')
   elif request.method == 'GET':
     form.body.data = postBody
+    form.date.data = date
+    form.month.data = month 
   return render_template('edit_post.html', title='Edit Post', form=form)
 
 @app.route('/reset_password_request', methods=['GET', 'POST'])

--- a/app/routes.py
+++ b/app/routes.py
@@ -122,8 +122,7 @@ def edit_profile():
 def edit_post():
   postBody = request.args.get('post')
   postId = request.args.get('postId')
-  month = request.args.get('month')
-  date = request.args.get('date')
+  timestamp = request.args.get('timestamp')
   givenPost = Post.query.filter_by(id=postId).first()
   form = EditPostForm(postBody)
   if form.validate_on_submit():
@@ -135,8 +134,8 @@ def edit_post():
       flash('Your changes have been saved.')
   elif request.method == 'GET':
     form.body.data = postBody
-    form.date.data = date
-    form.month.data = month 
+    form.date.data = timestamp.date
+    form.month.data = timestamp.month
   return render_template('edit_post.html', title='Edit Post', form=form)
 
 @app.route('/reset_password_request', methods=['GET', 'POST'])

--- a/app/routes.py
+++ b/app/routes.py
@@ -123,19 +123,20 @@ def edit_post():
   postBody = request.args.get('post')
   postId = request.args.get('postId')
   timestamp = request.args.get('timestamp')
+  oldDate = datetime.strptime(timestamp, "%Y-%m-%d %H:%M:%S.%f")
   givenPost = Post.query.filter_by(id=postId).first()
   form = EditPostForm(postBody)
   if form.validate_on_submit():
     if givenPost:
-      newDate = givenPost.timestamp.replace(day=form.timestamp.date, month=form.timestamp.month)
+      newDate = oldDate.replace(day=form.date.data, month=form.month.data)
       givenPost.body = form.body.data
       givenPost.timestamp = newDate
       db.session.commit()
       flash('Your changes have been saved.')
   elif request.method == 'GET':
     form.body.data = postBody
-    form.date.data = timestamp.date
-    form.month.data = timestamp.month
+    form.date.data = oldDate.date
+    form.month.data = oldDate.month
   return render_template('edit_post.html', title='Edit Post', form=form)
 
 @app.route('/reset_password_request', methods=['GET', 'POST'])

--- a/app/templates/_post.html
+++ b/app/templates/_post.html
@@ -8,7 +8,7 @@
        said {{ moment(post.timestamp).fromNow() }}:<br>
        {{ post.body }}
        {% if post.author.username == current_user.username %}
-       <a href="{{url_for('edit_post', post=post.body, postId=post.id) }}">Edit Post</p>       
+       <a href="{{url_for('edit_post', post=post.body, postId=post.id, month=( moment(post.timestamp).month()), date=(moment(post.timestamp).date())) }}">Edit Post</p>       
        {% endif %}
     </td>
   </tr>

--- a/app/templates/_post.html
+++ b/app/templates/_post.html
@@ -8,7 +8,7 @@
        said {{ moment(post.timestamp).fromNow() }}:<br>
        {{ post.body }}
        {% if post.author.username == current_user.username %}
-       <a href="{{url_for('edit_post', post=post.body, postId=post.id, month=( moment(post.timestamp).month()), date=(moment(post.timestamp).date())) }}">Edit Post</p>       
+       <a href="{{url_for('edit_post', post=post.body, postId=post.id, timestamp=post.timestamp) }}">Edit Post</p>       
        {% endif %}
     </td>
   </tr>

--- a/app/templates/edit_post.html
+++ b/app/templates/edit_post.html
@@ -11,6 +11,20 @@
       <span style="color: red;">[{{ error }}]</span>
       {% endfor %}
     </p>
+    <p>
+      {{ form.month.label }}<br>
+      {{ form.month() }}<br>
+      {% for error in form.month.errors %}
+      <span style="color: red;">[{{ error }}]</span>
+      {% endfor %}
+    </p>
+    <p>
+      {{ form.date.label }}<br>
+      {{ form.date() }}<br>
+      {% for error in form.date.errors %}
+      <span style="color: red;">[{{ error }}]</span>
+      {% endfor %}
+    </p>
     <p>{{ form.submit() }}</p>
   </form>
 {% endblock %}


### PR DESCRIPTION
### Allow user to set a date for a post

Currently we can set a date, but I'm not 100% sure that the date is being set correctly. 

Number values for dates and months were written to conform to Moment.js, but now I'm using python's datetime.

Also, it seems like months are getting set to a default in the form (incorrectly, but at least they're trying!!) whereas dates are getting defaulted to "1", so if you click "submit" to save changes to the text of the post, for example, you'll change the date to the first of (I think?) the next month *after* the post was originally published. Weird. 

Furthermore, I don't even know if the dates given and submitted are actually what's being saved, I'll need to check.